### PR TITLE
gd: hci: Ignore command READ_REMOTE_VERSION_INFORMATION result if isn't in command_queue_

### DIFF
--- a/system/gd/hci/hci_layer.cc
+++ b/system/gd/hci/hci_layer.cc
@@ -347,6 +347,10 @@ struct HciLayer::impl {
           auto view = CommandStatusView::Create(event);
           ASSERT(view.IsValid());
           auto op_code = view.GetCommandOpCode();
+          if (op_code == OpCode::READ_REMOTE_VERSION_INFORMATION) {
+            LOG_WARN("OpCode 0x%02hx (%s) is not in the command queue, skipped.", op_code, OpCodeText(op_code).c_str());
+            return;
+          }
           ASSERT_LOG(op_code == OpCode::NONE,
             "Received %s event with OpCode 0x%02hx (%s) without a waiting command"
             "(is the HAL sending commands, but not handling the events?)",


### PR DESCRIPTION
In MTK Dimensity 8100 devices, com.android.bluetooth will gets crash if try to connect a new device.

F DEBUG   : Abort message: 'assertion 'op_code == OpCode::NONE' failed - Received COMMAND_STATUS event with OpCode 0x41d (READ_REMOTE_VERSION_INFORMATION) without a waiting command(is the HAL sending commands, but not handling the events?)'

It means this command isn't in the command_queue_, we can just ignore it.